### PR TITLE
Fix resilience configuration and proxy handler

### DIFF
--- a/backend/src/main/java/com/rinhadebackend/config/ResilienceConfig.java
+++ b/backend/src/main/java/com/rinhadebackend/config/ResilienceConfig.java
@@ -17,7 +17,8 @@ public class ResilienceConfig {
         RetryConfig config = RetryConfig.custom()
                 .maxAttempts(3)
                 .waitDuration(Duration.ofMillis(50))
-                .intervalFunction(attempt -> Duration.ofMillis(50L * attempt))
+                // IntervalFunction expects a long value representing milliseconds
+                .intervalFunction(attempt -> 50L * attempt)
                 .retryExceptions(Exception.class)
                 .build();
         return Retry.of("processorRetry", config);

--- a/backend/src/main/java/com/rinhadebackend/service/PaymentService.java
+++ b/backend/src/main/java/com/rinhadebackend/service/PaymentService.java
@@ -5,7 +5,7 @@ import com.rinhadebackend.model.PaymentSummaryResponse;
 import com.rinhadebackend.model.ProcessorRequest;
 import com.rinhadebackend.model.ProcessorResponse;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
-import io.github.resilience4j.reactor.circuitbreaker.CircuitBreakerOperator;
+import io.github.resilience4j.reactor.circuitbreaker.operator.CircuitBreakerOperator;
 import io.github.resilience4j.reactor.retry.RetryOperator;
 import io.github.resilience4j.retry.Retry;
 import org.springframework.http.HttpStatus;

--- a/loadbalancer/src/main/java/com/rinhadeloadbalancer/LoadBalancerApplication.java
+++ b/loadbalancer/src/main/java/com/rinhadeloadbalancer/LoadBalancerApplication.java
@@ -18,7 +18,8 @@ public class LoadBalancerApplication {
                 .addHost(new URI(backend2))
                 .setConnectionsPerThread(20);
 
-        HttpHandler proxyHandler = new ProxyHandler(proxy, "http://localhost");
+        // Create the proxy handler using the configured proxy client
+        HttpHandler proxyHandler = new ProxyHandler(proxy);
 
         Undertow server = Undertow.builder()
                 .addHttpListener(80, "0.0.0.0")


### PR DESCRIPTION
## Summary
- Correct Undertow ProxyHandler usage to avoid type mismatch
- Fix Resilience4j retry interval configuration and import circuit breaker operator

## Testing
- `mvn -T 1C clean package -DskipTests` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a016183320832a99c0ac3f42fd51b0