### PR TITLE
Use local Docker images and conditional Docker Hub publish

### DIFF
--- a/build-and-run.sh
+++ b/build-and-run.sh
@@ -5,11 +5,11 @@ set -e
 mvn -T 1C clean package -DskipTests
 
 # Build Docker images in parallel for faster builds
-docker build -f Dockerfile.backend -t ghcr.io/calixto-neto/rinha-backend:latest . &
-docker build -f Dockerfile.loadbalancer -t ghcr.io/calixto-neto/rinha-loadbalancer:latest . &
+docker build -f Dockerfile.backend -t rinha-backend:latest . &
+docker build -f Dockerfile.loadbalancer -t rinha-loadbalancer:latest . &
 wait
 
-# Subir com Docker Compose
+# Subir com Docker Compose usando imagens locais
 cd participantes/calixto-neto/
-docker-compose up -d
+docker compose up -d
 echo "Aplicação buildada e rodando! Acesse via localhost:9999"

--- a/participantes/calixto-neto/docker-compose.yml
+++ b/participantes/calixto-neto/docker-compose.yml
@@ -1,7 +1,6 @@
-﻿version: '3.8'
 services:
   loadbalancer:
-    image: ghcr.io/calixto-neto/rinha-loadbalancer:latest
+    image: rinha-loadbalancer:latest
     ports:
       - "9999:80"
     environment:
@@ -21,7 +20,7 @@ services:
       - rinha-net
 
   backend1:
-    image: ghcr.io/calixto-neto/rinha-backend:latest
+    image: rinha-backend:latest
     environment:
       SPRING_REDIS_HOST: redis
       PAYMENT_PROCESSOR_DEFAULT_URL: http://payment-processor-default:8080
@@ -44,7 +43,7 @@ services:
       - payment-processor
 
   backend2:
-    image: ghcr.io/calixto-neto/rinha-backend:latest
+    image: rinha-backend:latest
     environment:
       SPRING_REDIS_HOST: redis
       PAYMENT_PROCESSOR_DEFAULT_URL: http://payment-processor-default:8080

--- a/publish-dockerhub.sh
+++ b/publish-dockerhub.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 
+# Só publica se houver alteração no pom.xml
+if git diff --quiet HEAD -- pom.xml; then
+  echo "pom.xml unchanged, skipping Docker Hub publish."
+  exit 0
+fi
+
 : "${DOCKERHUB_USERNAME:?}"
 : "${DOCKERHUB_TOKEN:?}"
 


### PR DESCRIPTION
## Summary
- Build local backend and load balancer images and run them via Docker Compose
- Use locally tagged images in docker-compose and drop obsolete version field
- Only push Docker Hub images when `pom.xml` changes

## Testing
- `bash -n build-and-run.sh publish-dockerhub.sh`
- `docker compose -f participantes/calixto-neto/docker-compose.yml config` *(fails: command not found)*
- `mvn -T 1C clean package -DskipTests` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a01967cde4832a8958ecae05995fee