### PR TITLE
Point compose to calixtusneto images

### DIFF
--- a/participantes/calixto-neto/docker-compose.yml
+++ b/participantes/calixto-neto/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   loadbalancer:
-    image: rinha-loadbalancer:latest
+    image: calixtusneto/rinha-loadbalancer:latest
     ports:
       - "9999:80"
     environment:
@@ -20,7 +20,7 @@ services:
       - rinha-net
 
   backend1:
-    image: rinha-backend:latest
+    image: calixtusneto/rinha-backend:latest
     environment:
       SPRING_REDIS_HOST: redis
       PAYMENT_PROCESSOR_DEFAULT_URL: http://payment-processor-default:8080
@@ -43,7 +43,7 @@ services:
       - payment-processor
 
   backend2:
-    image: rinha-backend:latest
+    image: calixtusneto/rinha-backend:latest
     environment:
       SPRING_REDIS_HOST: redis
       PAYMENT_PROCESSOR_DEFAULT_URL: http://payment-processor-default:8080


### PR DESCRIPTION
## Summary
- Use Docker Hub namespace `calixtusneto` for backend and load balancer images so `docker compose` pulls the correct repositories.

## Testing
- `yamllint participantes/calixto-neto/docker-compose.yml` *(fails: command not found)*
- `docker compose config -f participantes/calixto-neto/docker-compose.yml` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a01e9a7bc4832a85615d75393960e3