### PR TITLE
feat: compose for local builds

### DIFF
--- a/Dockerfile.loadbalancer
+++ b/Dockerfile.loadbalancer
@@ -6,7 +6,7 @@ WORKDIR /app
 COPY pom.xml ./
 COPY loadbalancer ./loadbalancer
 # build native executable for loadbalancer module
-RUN mvn -e -X -f loadbalancer/pom.xml -Pnative native:compile -DskipTests
+RUN mvn -f loadbalancer/pom.xml -Pnative native:compile -DskipTests
 
 FROM ubuntu:22.04
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-﻿# Rinha de Backend 2025 Monorepo
+# Rinha de Backend 2025 Monorepo
 
-Este Ã© um monorepo para o desafio Rinha de Backend 2025, contendo mÃ³dulos para o backend (compilado nativamente com GraalVM) e load balancer (baseado em Undertow).
+Este é um monorepo para o desafio Rinha de Backend 2025, contendo módulos para o backend (compilado nativamente com GraalVM) e load balancer (baseado em Undertow).
 
-## InstruÃ§Ãµes de Build e Deploy
+## Instruções de Build e Deploy
 
-1. Instale Maven e Docker.
-2. Execute ./build-and-run.sh para buildar os mÃ³dulos, criar imagens Docker e subir o ambiente com Docker Compose.
+1. Instale Docker.
+2. Execute `./build-and-run.sh` para buildar e subir o ambiente com Docker Compose usando as imagens locais.
 3. Acesse a aplicação via http://localhost:9999.

--- a/build-and-run.sh
+++ b/build-and-run.sh
@@ -1,15 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-# Build Maven modules using all CPU cores
-mvn -T 1C clean package -DskipTests
-
-# Build Docker images in parallel for faster builds
-docker build -f Dockerfile.backend -t rinha-backend:latest . &
-docker build -f Dockerfile.loadbalancer -t rinha-loadbalancer:latest . &
-wait
-
-# Subir com Docker Compose usando imagens locais
-cd participantes/calixto-neto/
-docker compose up -d
+# Subir com Docker Compose usando build local
+docker compose up -d --build
 echo "Aplicação buildada e rodando! Acesse via localhost:9999"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,94 @@
+services:
+  loadbalancer:
+    build:
+      context: .
+      dockerfile: Dockerfile.loadbalancer
+    ports:
+      - "9999:80"
+    environment:
+      BACKEND1_URL: http://backend1:8080
+      BACKEND2_URL: http://backend2:8080
+    deploy:
+      resources:
+        limits:
+          cpus: '0.15'
+          memory: 25M
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    networks:
+      - rinha-net
+
+  backend1:
+    build:
+      context: .
+      dockerfile: Dockerfile.backend
+    environment:
+      SPRING_REDIS_HOST: redis
+      PAYMENT_PROCESSOR_DEFAULT_URL: http://payment-processor-default:8080
+      PAYMENT_PROCESSOR_FALLBACK_URL: http://payment-processor-fallback:8080
+      JAVA_OPTS: -Xmx96m
+    deploy:
+      resources:
+        limits:
+          cpus: '0.45'
+          memory: 100M
+    depends_on:
+      - redis
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    networks:
+      - rinha-net
+      - payment-processor
+
+  backend2:
+    build:
+      context: .
+      dockerfile: Dockerfile.backend
+    environment:
+      SPRING_REDIS_HOST: redis
+      PAYMENT_PROCESSOR_DEFAULT_URL: http://payment-processor-default:8080
+      PAYMENT_PROCESSOR_FALLBACK_URL: http://payment-processor-fallback:8080
+      JAVA_OPTS: -Xmx96m
+    deploy:
+      resources:
+        limits:
+          cpus: '0.45'
+          memory: 100M
+    depends_on:
+      - redis
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    networks:
+      - rinha-net
+      - payment-processor
+
+  redis:
+    image: redis:latest
+    command: redis-server --maxmemory 75mb --maxmemory-policy allkeys-lru
+    deploy:
+      resources:
+        limits:
+          cpus: '0.45'
+          memory: 100M
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    networks:
+      - rinha-net
+
+networks:
+  rinha-net:
+    driver: bridge
+  payment-processor:
+    external: true


### PR DESCRIPTION
## Summary
- add root docker-compose to build load balancer and backend locally
- streamline build script to use local compose
- document local build workflow

## Testing
- `mvn -T 1C clean package -DskipTests` *(fails: Network is unreachable)*
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a035986030832a881c91e3e217ba7c