### PR TITLE
Fix Docker build for backend

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -5,8 +5,12 @@ WORKDIR /app
 # copy only the backend module and the parent pom to speed up build
 COPY pom.xml ./
 COPY backend ./backend
-# build native executable for backend module
-RUN mvn -f backend/pom.xml -Pnative native:compile -DskipTests
+# build native executable for backend module. The native-maven-plugin is
+# bound to the package phase when the `native` profile is enabled, so we run
+# the standard package goal instead of calling the plugin explicitly. Using
+# `package` avoids invoking a non-existent goal and lets Maven handle the
+# lifecycle correctly.
+RUN mvn -f backend/pom.xml -Pnative -DskipTests package
 
 FROM ubuntu:22.04
 WORKDIR /app


### PR DESCRIPTION
## Summary
- build backend native image via Maven package phase instead of calling native:compile goal directly

## Testing
- `mvn -f backend/pom.xml -Pnative -DskipTests package` *(fails: Non-resolvable parent POM ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a04b8e11d8832a8bc6bdf85f7c4e90